### PR TITLE
Implement scan_left functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-### Removed 
+### Removed
+
+## [0.1.0] - 2020-05-08
+### Added
+- Initial implementation of `ScanLeft`
 
 ## [0.0.1] - 2020-05-06
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
 # scan_left
-A tiny Ruby gem to provide the 'scan_left' operation on any Ruby Enumerable.
+A tiny Ruby gem to provide the 'scan_left' operation on any Ruby
+`Enumerable`.
+
+## What does it do?
+
+Imagine a series of numbers which you want to *sum*. You accomplish
+this by processing all elements, adding each to the previous sum,
+returning the final result.
+
+Now imagine that, rather than just the final sum at the end of the
+series, you want *a series* of the partial sums after processing each
+element. This is called a ["Prefix
+Sum"](https://en.wikipedia.org/wiki/Prefix_sum).
+
+In functional programming (FP), the *sum* is generalized as the *fold*
+operation, in which an initial state and a binary operation are
+combined to "fold" a series of values into a single result. The
+closely related *prefix sum*, which produces a series of intermediate
+results, is generalized as the *scan* operation. Adding "left" to
+these operation names indicates that calculation is to proceed
+left-to-right.
+
+## Compare / Contrast with #inject
+
+Ruby's standard library operation `Enumerable#inject` implements the
+FP fold operation. It also implements the simpler reduce operation,
+which is a fold whose initial state is the first element of the
+series.
+
+The key differences between `#inject` and `#scan_left` are:
+
+  1. Incremental results: `#scan_left` returns a series of results
+     after processing each element of the input series. `#inject`
+     returns a single value, which equals the final result in the
+     series returned by `#scan_left`.
+
+  2. Laziness: `#scan_left` can preserve the laziness of the input
+     series.  As each incremental result is read from the output
+     series, the actual calculation is lazily performed against the
+     input. `#inject` cannot be a a lazy operation in general, as its
+     single result reflects a calculation across every element of the
+     input series.
+
+## Examples
+
+```
+require 'scan_left'
+
+ScanLeft.new([]).scan_left(0) { |s, x| s + x } == [0]
+[].inject(0) { |s, x| s + x }                  == 0
+
+ScanLeft.new([1]).scan_left(0) { |s, x| s + x } == [0, 1]
+[1].inject(0) { |s, x| s + x }                  == 1
+
+ScanLeft.new([1, 2, 3]).scan_left(0) { |s, x| s + x } == [0, 1, 3, 6]
+[1, 2, 3].inject(0) { |s, x| s + x }                  == 6
+```
+
+## Further Reading
+
+  * https://en.wikipedia.org/wiki/Fold_(higher-order_function)
+  * https://en.wikipedia.org/wiki/Prefix_sum#Scan_higher_order_function
+  * http://alvinalexander.com/scala/how-to-walk-scala-collections-reduceleft-foldright-cookbook#scanleft-and-scanright

--- a/lib/scan_left.rb
+++ b/lib/scan_left.rb
@@ -2,7 +2,48 @@
 
 require "scan_left/version"
 
-module ScanLeft
-  class Error < StandardError; end
-  # Your code goes here...
+# Original author: [Marc Siegel](https://github.com/ms-ati).
+
+# Provides the `#scan_left` operation on any Enumerable.
+class ScanLeft
+  attr_reader :enumerable
+
+  # @param [Enumerable]  enumerable  Stream to transform via `scan_left`
+  def initialize(enumerable)
+    @enumerable = enumerable
+  end
+
+  # Map the enumerable to the incremental state of a calculation by
+  # applying the given block, in turn, to each element and the
+  # previous state of the calculation, resulting in an enumerable of
+  # the state after each iteration.
+  #
+  # @return [Enumerable] Generate a stream of intermediate states
+  #   resulting from applying a binary operator. Equivalent to a
+  #   stream of `#inject` calls on first N elements, increasing N from
+  #   zero to the size of the stream. NOTE: Preserves laziness if
+  #   `enumerable` is lazy.
+  #
+  # @param initial [Object] Initial state value to yield.
+  #
+  # @yield [memo, obj] Invokes given block with previous state value
+  #   `memo` and next element of the stream `obj`.
+  #
+  # @yieldreturn [Object] The next state value for `memo`.
+  def scan_left(initial)
+    memo = initial
+    outs = enumerable.map { |*obj| memo = yield(memo, *obj) }
+    prepend_preserving_laziness(value: initial, enum: outs)
+  end
+
+  private
+
+  def prepend_preserving_laziness(value:, enum:)
+    case enum
+    when Enumerator::Lazy
+      [[value], enum].lazy.flat_map { |x| x }
+    else
+      [value] + enum
+    end
+  end
 end

--- a/lib/scan_left/version.rb
+++ b/lib/scan_left/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module ScanLeft
-  VERSION = "0.0.1"
+class ScanLeft
+  VERSION = "0.1.0"
 end

--- a/scan_left.gemspec
+++ b/scan_left.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
                      "any Ruby Enumerable."
   spec.description = spec.summary
   spec.homepage    = "https://github.com/panorama-ed/scan_left"
+  spec.license     = "MIT"
 
   if spec.respond_to?(:metadata)
     spec.metadata["allowed_push_host"] = "https://rubygems.org/" # allow pushes

--- a/spec/scan_left_spec.rb
+++ b/spec/scan_left_spec.rb
@@ -1,12 +1,67 @@
 # frozen_string_literal: true
 
 RSpec.describe ScanLeft do
-  it "has a version number" do
-    expect(ScanLeft::VERSION).not_to be nil
+  subject { described_class.new(enumerable).scan_left(initial, &block) }
+
+  # Uses the following lets:
+  #   - enumerable  The stream to transform
+  #   - initial     The initial value to use
+  #   - block       The binary operation to use
+  shared_examples "a_series_of_injects" do
+    let(:series_of_intermediate_inject_results) do
+      slices = (0..enumerable.size).map { |n| enumerable.take(n) }
+      slices.map { |slice| slice.inject(initial, &block) }
+    end
+
+    it "equals a series of intermediate results from #inject" do
+      expect(subject.to_a).to eq series_of_intermediate_inject_results
+    end
+
+    it "preserves laziness" do
+      if enumerable.is_a?(Enumerator::Lazy)
+        is_expected.to be_a(Enumerator::Lazy)
+      else
+        is_expected.not_to be_a(Enumerator::Lazy)
+      end
+    end
   end
 
-  it "does something useful" do
-    dummy = false
-    expect(dummy).to eq(true)
+  context "when summing ints" do
+    let(:initial) { 0 }
+    let(:block) { ->(memo, obj) { memo + obj } }
+
+    context "with zero elements" do
+      let(:enumerable) { [] }
+
+      it_behaves_like "a_series_of_injects"
+    end
+
+    context "with a single element" do
+      let(:enumerable) { [1] }
+
+      it_behaves_like "a_series_of_injects"
+    end
+
+    context "with multiple elements" do
+      let(:enumerable) { (1..5).to_a }
+
+      it_behaves_like "a_series_of_injects"
+
+      context "lazy" do
+        let(:enumerable) { super().lazy }
+
+        it_behaves_like "a_series_of_injects"
+      end
+    end
+  end
+
+  context "when using #with_index" do
+    let(:initial) { 0 }
+    let(:enumerable) { [1, 2, 3].each.with_index }
+    let(:block) { ->(memo, obj, index) { memo + obj + index } }
+
+    it "passes the correct number of arguments to produce the correct result" do
+      expect(subject).to eq([0, 1, 4, 9])
+    end
   end
 end


### PR DESCRIPTION
Move our implementation of `#scan_left` to a public repository.