### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+# Reference: https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"
+
+    # Automerge development dependencies.
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"


### PR DESCRIPTION
This adds a config so that dependabot will start updating our
dependencies. We pull in dependency updates as quickly as possible and
automatically update development dependencies.