### PR TITLE
Remove unused Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.5.8
-before_install: gem install bundler -v 1.17.3


### PR DESCRIPTION
This repo uses Github Actions for CI, the Travis CI config
is unused.