### PR TITLE
Only run linters, and install gem panolint, on Ruby 2.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,5 @@ jobs:
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
     - run: bundle exec rubocop
+      if: matrix.ruby == 2.7
     - run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :development do
-  gem "panolint", github: "panorama-ed/panolint"
+  if RUBY_VERSION.start_with?("2.7")
+    # Match only Ruby version we run the linters on in CI
+    gem "panolint", github: "panorama-ed/panolint"
+  end
 end


### PR DESCRIPTION
Currently a rubocop dependency is breaking on JRuby. By only
running linters on Ruby 2.7, and also only installing the linter
dependency tree via 'panolint' gem on Ruby 2.7, we can ignore
compatibility breakages in this dependency tree that shouldn't
be taking our attention.