### PR TITLE
Add Ruby 3.0 to spec matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ 2.5, 2.6, 2.7, jruby ]
+        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby ]
     runs-on: ${{ matrix.os }}
     env:
       CI: true

--- a/spec/enumerable_with_scan_left_spec.rb
+++ b/spec/enumerable_with_scan_left_spec.rb
@@ -7,14 +7,11 @@ RSpec.describe EnumerableWithScanLeft do
 
   subject { enumerable.scan_left(initial, &block) }
 
-  # Right now there's a bug in either rspec or ruby that prevents
-  # these specs from passing on ruby 2.7. See:
+  # There is a bug in Ruby 2.7 that prevents these specs from passing. See:
   #   * https://github.com/rspec/rspec-core/issues/2727
   #   * https://bugs.ruby-lang.org/issues/16852
   #
   # Until this is resolved, we skip these specs on Ruby 2.7.
-  #
-  # UPDATE 20200902: It seems like this will be fixed in Ruby 2.7.2.
-  pending_msg = "Known bug in Ruby 2.7.1" if RUBY_VERSION.start_with?("2.7")
+  pending_msg = "Known bug in Ruby 2.7" if RUBY_VERSION.start_with?("2.7")
   include_examples "scan_left_examples", skip: pending_msg
 end


### PR DESCRIPTION
We were hopeful that the refinement bug would be fixed in Ruby 2.7.2,
but the fix only appears in Ruby 3. So, at least for now, continue to
skip specs when running on Ruby 2.7.