### PR TITLE
Fix Github Actions CI to use Ruby 3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby ]
+        # Due to https://github.com/actions/runner/issues/849, we have to use
+        # quotes for '3.0'. Without quotes, CI runs 3.1.1, which fails due to
+        # https://github.com/rubygems/rubygems/issues/5234 as of 2022-02-28.
+        ruby: [ 2.5, 2.6, 2.7, '3.0', jruby ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR puts quotes (e.g. '3.0') around the Ruby version 3.0,
as without this change it ends up using 3.1.1 now, and triggers
an error on that version due to an issue with the Bundler version
it uses.

See:
https://github.com/actions/runner/issues/849
https://github.com/rubygems/rubygems/issues/5234