### PR TITLE
IOPZ-2706 Fix bug in Dependabot automerging

### DIFF
--- a/.github/workflows/dependabot-prs.yml
+++ b/.github/workflows/dependabot-prs.yml
@@ -4,29 +4,47 @@ on:
     types: [opened, synchronize, reopened, labeled]
 jobs:
   build:
+    if: startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-    - name: Fetch Dependabot metadata
-      id: dependabot-metadata
-      uses: dependabot/fetch-metadata@v1.1.0
-      with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Approve and merge Dependabot PRs for development dependencies
-      # Auto-merge the PR if either:
-      # a) it has the `development-dependencies` label, which we add for certain
-      #    categories of PRs (see `.github/dependabot.yml`), OR
-      # b) Dependabot has categorized it as a `direct:development` dependency,
-      #    meaning it's in the Gemfile in a `development` or `test` group
-      #
-      # Note that we also do nothing when the PR has already had auto-merge
-      # enabled, to prevent scenarios where this check runs many times (for
-      # instance, because removing `Needs QA` triggers another run, or because
-      # other PRs are merging and causing this to rebase and trigger another
-      # run) and then approves the PR many times, which is confusing and looks
-      # awkward.
-      if: ${{ !github.event.pull_request.auto_merge && (contains(github.event.pull_request.labels.*.name, 'development-dependencies') || steps.dependabot-metadata.outputs.dependency-type == 'direct:development') }}
-      run: gh pr merge --auto --merge "$PR_URL" && gh pr edit "$PR_URL" --remove-label "Needs QA" && gh pr review --approve "$PR_URL"
-      env:
-        PR_URL: ${{github.event.pull_request.html_url}}
-        GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}
+      - name: Get unique committers
+        id: unique-committers
+        run: echo "::set-output name=committers::$(gh pr view $PR_URL --json commits --jq '[.commits.[] | .authors.[] | .login] | unique')"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}
+      # The last step enables auto-merge in certain situations, but we don't want dependabots that require
+      # additional work to accidentally get merged before code review so we turn it off here.
+      - name: Disable auto-merge if there are commits from someone other than Dependabot
+        if: steps.unique-committers.outputs.committers != '["dependabot[bot]"]'
+        run: gh pr merge --disable-auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}
+      - name: Add the Needs QA label to dependabots after any change by someone other than the dependabot bot
+        # Need to avoid the situation where someone removes the "Needs QA" label and we are adding it back.
+        if: ${{ github.actor != 'dependabot[bot]' && github.event.action != 'labeled' }}
+        run: gh pr edit "$PR_URL" --add-label "Needs QA"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}
+      - name: Fetch Dependabot metadata
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve and merge Dependabot PRs for development dependencies
+        # Auto-merge the PR if either:
+        # a) it has the `development-dependencies` label, which we add for certain
+        #    categories of PRs (see `.github/dependabot.yml`), OR
+        # b) Dependabot has categorized it as a `direct:development` dependency,
+        #    meaning it's in the Gemfile in a `development` or `test` group, OR
+        # c) our scripts have flagged the PR as an automergeable dependency (i.e
+        #    a stable dependency with good unit test coverage) that has passed
+        #    the waiting period.
+        if: ${{ (github.actor == 'dependabot[bot]' || github.actor == 'panorama-bot-r') && steps.unique-committers.outputs.committers == '["dependabot[bot]"]' && (contains(github.event.pull_request.labels.*.name, 'development-dependencies') || steps.dependabot-metadata.outputs.dependency-type == 'direct:development' || contains(github.event.pull_request.labels.*.name, 'automerge-dependencies')) }}
+        run: gh pr merge --auto --merge "$PR_URL" && gh pr edit "$PR_URL" --remove-label "Needs QA" && gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}


### PR DESCRIPTION
This commit fixes a bug where if a safe-for-automerge Dependabot PR gets created and then rebased in quick succession (for example because another Depdendabot PR auto-merged), our automation would not re-approve it after rebase which our branch protection rules require for it to get merged.