### PR TITLE
CIIZ-3312: Update github actions permissions

### DIFF
--- a/.github/workflows/dependabot-prs.yml
+++ b/.github/workflows/dependabot-prs.yml
@@ -1,4 +1,7 @@
 name: Dependabot Pull Request
+permissions:
+  contents: read
+  pull-requests: read
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Main
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Since the github.action is not used to do any writing and only PANORAMA_BOT_RW_TOKEN is used for edits/merging, all permissions can be set to read usage only


## Workflow permissions summary

### `.github/workflows/tests.yml`
- `permissions:`
  - `contents: read`
- Reason: this workflow only checks out the repo and runs local Ruby commands (`bundle exec rspec`, `bundle exec rubocop`).

### `.github/workflows/dependency-review.yml`
- Already set correctly:
  - `contents: read`
- Reason: `actions/checkout@v3` + `actions/dependency-review-action@v3` only need read access to repository contents.

### `.github/workflows/dependabot-prs.yml`
- `permissions:`
  - `contents: read`
  - `pull-requests: read`
- Reason: `dependabot/fetch-metadata` on `pull_request_target` needs PR read access and repo contents read.

### Important note about `gh pr merge`
- The merge/edit/review commands in `dependabot-prs.yml` use:
  - `GITHUB_TOKEN: ${{ secrets.PANORAMA_BOT_RW_TOKEN }}`
- That means they are authenticated with a separate token/secret, not the built-in `github.token`.
- Therefore the workflow-level `permissions` block does not need `pull-requests: write` for those commands.

### If you changed to use the built-in token
- If `gh pr merge`, `gh pr edit`, or `gh pr review` were authenticated with `github.token`, then the workflow would need:
  - `pull-requests: write`
  - and for auto-merge scenarios likely `contents: write`



Testing using a workflow file change (since removed from commit history)
<img width="670" height="670" alt="image" src="https://github.com/user-attachments/assets/c52b4fee-c7b4-4000-bfbe-0eee6ce3e78e" />

